### PR TITLE
Switch to circe-config instead of pureconfig

### DIFF
--- a/auth/src/main/resources/reference.conf
+++ b/auth/src/main/resources/reference.conf
@@ -2,7 +2,7 @@ db {
   host: 127.0.0.1
   port: 5432
   user: postgres
-  database-name: "ct_auth"
+  databaseName: "ct_auth"
   password: ""
-  schema-name: "ct_auth"
+  schemaName: "ct_auth"
 }

--- a/auth/src/test/resources/reference.conf
+++ b/auth/src/test/resources/reference.conf
@@ -2,7 +2,7 @@ db {
   host: 127.0.0.1
   port: 5432
   user: postgres
-  database-name: "ct_auth_test"
+  databaseName: "ct_auth_test"
   password: ""
-  schema-name: "ct_auth"
+  schemaName: "ct_auth"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ val commonSettings = Seq(
   scalacOptions in (Compile, console) ~= (_.filterNot(options.badScalacConsoleFlags.contains(_)))
 ) ++ compilerPlugins
 
+
 lazy val publishSettings = Seq(
   useGpg := true,
   publishMavenStyle := true,

--- a/db/src/main/scala/h4sm/db/config/DatabaseConfig.scala
+++ b/db/src/main/scala/h4sm/db/config/DatabaseConfig.scala
@@ -9,7 +9,7 @@ import org.flywaydb.core.api.FlywayException
 
 final case class DatabaseConfig(
   host: String,
-  port: String,
+  port: Int,
   user: String,
   password: String,
   databaseName: String

--- a/features/src/main/resources/reference.conf
+++ b/features/src/main/resources/reference.conf
@@ -1,9 +1,13 @@
-host : 127.0.0.1
-port : 127.0.0.1
-db {
-  host: 127.0.0.1
-  port: 5432
-  user: postgres
-  database-name: "feature_requests"
-  password: ""
+{
+  server {
+    host : 127.0.0.1
+    port : 8080
+  }
+  db {
+    host: 127.0.0.1
+    port: 5432
+    user: postgres
+    databaseName: "feature_requests"
+    password: ""
+  }
 }

--- a/features/src/test/resources/reference.conf
+++ b/features/src/test/resources/reference.conf
@@ -4,7 +4,7 @@ db {
   host: 127.0.0.1
   port: 5432
   user: postgres
-  database-name: "ct_feature_requests_test"
+  databaseName: "ct_feature_requests_test"
   password: ""
-  schema-name: "ct_feature_requests"
+  schemaName: "ct_feature_requests"
 }

--- a/features/src/test/scala/h4sm/featurerequests/db/sql/testTransactor.scala
+++ b/features/src/test/scala/h4sm/featurerequests/db/sql/testTransactor.scala
@@ -1,17 +1,26 @@
 package h4sm.featurerequests.db
 package sql
 
+import cats.syntax.either._
 import cats.effect.IO
+import com.typesafe.config.ConfigFactory
 import doobie.util.transactor.Transactor
 import h4sm.db.config.DatabaseConfig
 import h4sm.dbtesting.transactor.getInitializedTransactor
-
+import io.circe.config.syntax._
+import io.circe.generic.auto._
 import scala.concurrent.ExecutionContext
 
 object testTransactor {
   implicit lazy val cs = IO.contextShift(ExecutionContext.Implicits.global)
 
-  val cfg = pureconfig.loadConfigOrThrow[DatabaseConfig]("db")
+  def getTransactor : IO[Transactor[IO]] =
+    ConfigFactory
+      .load()
+      .as[DatabaseConfig]("db")
+      .leftMap(_.asInstanceOf[Throwable])
+      .raiseOrPure[IO]
+      .flatMap(getInitializedTransactor(_, "ct_auth", "featurerequests"))
 
-  lazy val testTransactor: Transactor[IO] = getInitializedTransactor(cfg, "ct_auth", "featurerequests").unsafeRunSync()
+  lazy val testTransactor: Transactor[IO] = getTransactor.unsafeRunSync()
 }

--- a/files/src/main/resources/reference.conf
+++ b/files/src/main/resources/reference.conf
@@ -1,17 +1,19 @@
-files {
-  backend: "local"
-  base-path: "/Users/zak/filestest"
-  upload-max = 20000000
-}
-db {
-  host: 127.0.0.1
-  port: 5432
-  user: postgres
-  database-name: "ct_files"
-  password: ""
-  schema-name: "ct_files"
-}
-server {
-  host : 127.0.0.1
-  port : 8081
+{
+  files {
+    backend: "local"
+    basePath: "/Users/zak/filestest"
+    uploadMax = 20000000
+  }
+  db {
+    host: 127.0.0.1
+    port: 5432
+    user: postgres
+    databaseName: "ct_files"
+    password: ""
+    schemaName: "ct_files"
+  }
+  server {
+    host : 127.0.0.1
+    port : 8081
+  }
 }

--- a/files/src/main/scala/h4sm/files/Main.scala
+++ b/files/src/main/scala/h4sm/files/Main.scala
@@ -1,15 +1,16 @@
 package h4sm.files
 
-import cats.Applicative
+import cats.ApplicativeError
 import cats.effect._
 import h4sm.db.config.DatabaseConfig
 import h4sm.files.config._
 import scala.concurrent.ExecutionContext.Implicits.global
+import io.circe.generic.auto._
 
 trait Configs[F[_]]{
-  implicit def ca(implicit F : Applicative[F]) : ConfigAsk[F] = config.getConfigAsk[F, FileConfig]("files")
-  implicit def da(implicit F : Applicative[F]) : DBConfigAsk[F] = config.getConfigAsk[F, DatabaseConfig]("db")
-  implicit def sa(implicit F : Applicative[F]) : ServerConfigAsk[F] = config.getConfigAsk[F, ServerConfig]("server")
+  implicit def ca(implicit F : ApplicativeError[F, Throwable]) : ConfigAsk[F] = config.getConfigAsk[F, FileConfig]("files")
+  implicit def da(implicit F : ApplicativeError[F, Throwable]) : DBConfigAsk[F] = config.getConfigAsk[F, DatabaseConfig]("db")
+  implicit def sa(implicit F : ApplicativeError[F, Throwable]) : ServerConfigAsk[F] = config.getConfigAsk[F, ServerConfig]("server")
 }
 
 

--- a/files/src/main/scala/h4sm/files/config/package.scala
+++ b/files/src/main/scala/h4sm/files/config/package.scala
@@ -1,24 +1,24 @@
 package h4sm.files
 
-import cats.Applicative
+import cats.{Applicative, ApplicativeError}
 import cats.mtl.ApplicativeAsk
-import cats.syntax.applicative._
+import cats.syntax.either._
 import cats.syntax.functor._
+import com.typesafe.config.ConfigFactory
 import h4sm.db.config.DatabaseConfig
-import pureconfig.ConfigReader
-
-import scala.reflect.ClassTag
+import io.circe.Decoder
+import io.circe.config.syntax._
 
 package object config {
   type ConfigAsk[F[_]] = ApplicativeAsk[F, FileConfig]
   type DBConfigAsk[F[_]] = ApplicativeAsk[F, DatabaseConfig]
   type ServerConfigAsk[F[_]] = ApplicativeAsk[F, ServerConfig]
 
-  def getConfigAsk[F[_] : Applicative, E : ClassTag : ConfigReader](name : String) : ApplicativeAsk[F, E] = {
-    val c = pureconfig.loadConfigOrThrow[E](name)
+  def getConfigAsk[F[_], E: Decoder](name : String)(implicit ev : ApplicativeError[F, Throwable]) : ApplicativeAsk[F, E] = {
+    val c = ConfigFactory.load().as[E](name).leftMap(_.asInstanceOf[Throwable]).raiseOrPure[F]
     new ApplicativeAsk[F, E] {
       val applicative: Applicative[F] = Applicative[F]
-      def ask: F[E] = c.pure[F]
+      def ask: F[E] = c
       def reader[A](f: E => A): F[A] = ask.map(f)
     }
   }

--- a/files/src/test/resources/reference.conf
+++ b/files/src/test/resources/reference.conf
@@ -1,17 +1,19 @@
-files {
-  backend: "local"
-  basePath: "/Users/zak/filestest"
-  uploadMax = 20000000
-}
-db {
-  host: 127.0.0.1
-  port: 5432
-  user: postgres
-  database-name: "ct_files_test"
-  password: ""
-  schema-name: "ct_files"
-}
-server {
-  host : 127.0.0.1
-  port : 8081
+{
+  files {
+    backend: "local"
+    basePath: "/Users/zak/filestest"
+    uploadMax = 20000000
+  }
+  db {
+    host: 127.0.0.1
+    port: 5432
+    user: postgres
+    databaseName: "ct_files_test"
+    password: ""
+    schemaName: "ct_files"
+  }
+  server {
+    host : 127.0.0.1
+    port : 8081
+  }
 }

--- a/files/src/test/scala/h4sm/files/infrastructure/endpoint/EndpointsTestSpec.scala
+++ b/files/src/test/scala/h4sm/files/infrastructure/endpoint/EndpointsTestSpec.scala
@@ -5,18 +5,20 @@ package endpoint
 import java.io.{ByteArrayOutputStream, File, PrintStream}
 
 import cats.effect.IO
+import cats.implicits._
+import doobie.implicits._
 import h4sm.auth.client.{AuthClient, IOTestAuthClient}
 import h4sm.auth.infrastructure.endpoint.{AuthEndpoints, UserRequest}
-import org.scalatest._
-import org.scalatest.prop.PropertyChecks
-import tsec.passwordhashers.jca.BCrypt
 import h4sm.files.config.FileConfig
 import h4sm.files.domain.FileInfo
 import h4sm.files.infrastructure.backends._
 import h4sm.files.db.sql.{files => filesSql}
 import h4sm.files.db.sql.arbitraries._
-import doobie.implicits._
-import cats.implicits._
+import io.circe.generic.auto._
+import org.scalatest._
+import org.scalatest.prop.PropertyChecks
+import tsec.passwordhashers.jca.BCrypt
+
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/h4sm-docs/src/main/resources/reference.conf
+++ b/h4sm-docs/src/main/resources/reference.conf
@@ -1,9 +1,11 @@
-host : 127.0.0.1
-port : 127.0.0.1
+server {
+  host : 127.0.0.1
+  port: 8080
+}
 db {
   host: 127.0.0.1
   port: 5432
   user: postgres
-  database-name: "h4sm_docs_gen"
+  databaseName: "h4sm_docs_gen"
   password: ""
 }

--- a/permissions/src/main/resources/reference.conf
+++ b/permissions/src/main/resources/reference.conf
@@ -1,7 +1,9 @@
-db {
-  host: 127.0.0.1
-  port: 5432
-  user: postgres
-  database-name: "ct_permissions"
-  password: ""
+{
+  db {
+    host: 127.0.0.1
+    port: 5432
+    user: postgres
+    databaseName: "ct_permissions"
+    password: ""
+  }
 }

--- a/permissions/src/test/resources/reference.conf
+++ b/permissions/src/test/resources/reference.conf
@@ -1,7 +1,9 @@
-db {
-  host: 127.0.0.1
-  port: 5432
-  user: postgres
-  database-name: "ct_permissions_test"
-  password: ""
+{
+  db {
+    host: 127.0.0.1
+    port: 5432
+    user: postgres
+    databaseName: "ct_permissions_test"
+    password: ""
+  }
 }

--- a/permissions/src/test/scala/h4sm/permissions/infrastructure/repository/persistent/sql/transactor.scala
+++ b/permissions/src/test/scala/h4sm/permissions/infrastructure/repository/persistent/sql/transactor.scala
@@ -1,18 +1,25 @@
 package h4sm.permissions.infrastructure.repository.persistent.sql
 
 import cats.effect.{Async, ContextShift, IO}
+import cats.implicits._
+import com.typesafe.config.ConfigFactory
 import doobie.util.transactor.Transactor
 import h4sm.db.config.DatabaseConfig
 import h4sm.dbtesting.transactor.getInitializedTransactor
+import io.circe.config.syntax._
+import io.circe.generic.auto._
 
 import scala.concurrent.ExecutionContext
 
 object transactor {
-  def getTestTransactor[F[_] : Async : ContextShift](cfg : DatabaseConfig) =
-    getInitializedTransactor[F](cfg, "ct_auth", "ct_permissions")
-
-  lazy val cfg = pureconfig.loadConfigOrThrow[DatabaseConfig]("db")
+  def getTestTransactor[F[_] : Async : ContextShift]: F[doobie.Transactor[F]] =
+    ConfigFactory
+      .load()
+      .as[DatabaseConfig]("db")
+      .leftMap(_.asInstanceOf[Throwable])
+      .raiseOrPure[F]
+      .flatMap(getInitializedTransactor[F](_, "ct_auth", "ct_permissions"))
 
   implicit lazy val cs = IO.contextShift(ExecutionContext.Implicits.global)
-  lazy val testTransactor : Transactor[IO] = getTestTransactor[IO](cfg).unsafeRunSync()
+  lazy val testTransactor : Transactor[IO] = getTestTransactor[IO].unsafeRunSync()
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,13 +18,13 @@ object dependencies {
   val catsMtl = "0.4.0"
   val catsEffect = "1.1.0"
   val circe = "0.11.0"
+  val circeConfig = "0.6.0"
   val cryptobits = "1.1"
   val doobie = "0.6.0"
   val flyway = "5.2.4"
   val http4s = "0.20.0-M4"
   val logback = "1.2.3"
   val postgres = "42.2.5"
-  val pureConfig = "0.9.2"
   val scalaCheck = "1.14.0"
   val scalaTest = "3.0.5"
   val simulacrum = "0.14.0"
@@ -40,7 +40,9 @@ object dependencies {
     "circe-generic",
     "circe-parser",
     "circe-java8"
-  ).map("io.circe" %% _ % circe)
+  ).map("io.circe" %% _ % circe) ++ Seq(
+    "io.circe" %% "circe-config" % circeConfig
+  )
 
   val testDeps = Seq(
     "org.scalatest" %% "scalatest" % scalaTest,
@@ -64,7 +66,6 @@ object dependencies {
     "cats-effect" -> catsEffect,
     "cats-mtl-core" -> catsMtl
   ).map(("org.typelevel" %% (_ : String) % (_: String)).tupled) ++ Seq(
-    "com.github.pureconfig" %% "pureconfig" % pureConfig,
     "ch.qos.logback" %  "logback-classic" % logback,
     "com.github.mpilquist" %% "simulacrum" % simulacrum
   ) 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -3,18 +3,18 @@
     host: 127.0.0.1
     port: 5432
     user: postgres
-    database-name: "ct_h4sm_root"
+    databaseName: "ct_h4sm_root"
     password: ""
   }
   files {
     backend : "local",
-    base-path : "/tmp",
-    upload-max : 32
+    basePath : "/tmp",
+    uploadMax : 32
   }
   server {
     host : 127.0.0.1
     port : 8080
-    num-threads : 32
+    numThreads : 32
   }
   test : false
 }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -3,18 +3,18 @@
     host: 127.0.0.1
     port: 5432
     user: postgres
-    database-name: "ct_h4sm_root_test"
+    databaseName: "ct_h4sm_root_test"
     password: ""
   }
   files {
     backend : "local",
-    base-path : "/tmp",
-    upload-max : 32
+    basePath : "/tmp",
+    uploadMax : 32
   }
   server {
     host : 127.0.0.1
     port : 8080
-    num-threads : 32
+    numThreads : 32
   }
   test : true
 }


### PR DESCRIPTION
Many changes required:

* kebab-case -> camelCase, since circe doesn't apply this transform
* You'll see `.asInstanceOf[Throwable].raiseOrPure[F]` a lot. Circe-config has its own parse error, which extends `Exception`. This is the natural way to switch from `Either[Error, A]` to `F[A]`, while allowing the error to be handled in the context of F, which has an `ApplicativeError` instance for `Throwable`.