### PR TITLE
Remove asInstanceOf usage

### DIFF
--- a/auth/src/test/scala/h4sm/auth/infrastructure/package.scala
+++ b/auth/src/test/scala/h4sm/auth/infrastructure/package.scala
@@ -2,7 +2,7 @@ package h4sm
 package auth
 
 import cats.effect.IO
-import cats.syntax.either._
+import cats.implicits._
 import com.typesafe.config.ConfigFactory
 import doobie.util.transactor.Transactor
 import h4sm.db.config.DatabaseConfig
@@ -18,7 +18,7 @@ package object infrastructure {
     ConfigFactory
       .load()
       .as[DatabaseConfig]("db")
-      .leftMap(_.asInstanceOf[Throwable])
+      .leftWiden[Throwable]
       .raiseOrPure[IO]
       .flatMap(getInitializedTransactor(_, "ct_auth"))
 

--- a/features/src/main/scala/h4sm/featurerequests/Server.scala
+++ b/features/src/main/scala/h4sm/featurerequests/Server.scala
@@ -42,7 +42,7 @@ class Server[F[_] : ConcurrentEffect : Timer : ContextShift] {
   }
 
   def run(ec : ExecutionContext) : F[ExitCode] = for {
-    cfg <- ConfigFactory.load().as[FeatureRequestConfig].leftMap(_.asInstanceOf[Throwable]).raiseOrPure[F]
+    cfg <- ConfigFactory.load().as[FeatureRequestConfig].leftWiden[Throwable].raiseOrPure[F]
     FeatureRequestConfig(host, port, db) = cfg
     _ <- E.delay(DatabaseConfig.initialize(db)("ct_auth", "featurerequests"))
     exitCode <- HikariTransactor

--- a/features/src/test/scala/h4sm/featurerequests/db/sql/testTransactor.scala
+++ b/features/src/test/scala/h4sm/featurerequests/db/sql/testTransactor.scala
@@ -1,8 +1,8 @@
 package h4sm.featurerequests.db
 package sql
 
-import cats.syntax.either._
 import cats.effect.IO
+import cats.implicits._
 import com.typesafe.config.ConfigFactory
 import doobie.util.transactor.Transactor
 import h4sm.db.config.DatabaseConfig
@@ -18,7 +18,7 @@ object testTransactor {
     ConfigFactory
       .load()
       .as[DatabaseConfig]("db")
-      .leftMap(_.asInstanceOf[Throwable])
+      .leftWiden[Throwable]
       .raiseOrPure[IO]
       .flatMap(getInitializedTransactor(_, "ct_auth", "featurerequests"))
 

--- a/files/src/main/scala/h4sm/files/config/package.scala
+++ b/files/src/main/scala/h4sm/files/config/package.scala
@@ -2,8 +2,7 @@ package h4sm.files
 
 import cats.{Applicative, ApplicativeError}
 import cats.mtl.ApplicativeAsk
-import cats.syntax.either._
-import cats.syntax.functor._
+import cats.implicits._
 import com.typesafe.config.ConfigFactory
 import h4sm.db.config.DatabaseConfig
 import io.circe.Decoder
@@ -15,7 +14,7 @@ package object config {
   type ServerConfigAsk[F[_]] = ApplicativeAsk[F, ServerConfig]
 
   def getConfigAsk[F[_], E: Decoder](name : String)(implicit ev : ApplicativeError[F, Throwable]) : ApplicativeAsk[F, E] = {
-    val c = ConfigFactory.load().as[E](name).leftMap(_.asInstanceOf[Throwable]).raiseOrPure[F]
+    val c = ConfigFactory.load().as[E](name).leftWiden[Throwable].raiseOrPure[F]
     new ApplicativeAsk[F, E] {
       val applicative: Applicative[F] = Applicative[F]
       def ask: F[E] = c

--- a/files/src/main/scala/h4sm/files/infrastructure/endpoint/FileEndpoints.scala
+++ b/files/src/main/scala/h4sm/files/infrastructure/endpoint/FileEndpoints.scala
@@ -92,7 +92,7 @@ class FileEndpoints[F[_]](auth : AuthEndpoints[F, _])(implicit
     case POST -> Root / uuid asAuthed _ => for {
       uuid <- S.delay(UUID.fromString(uuid))
       fileInfo <- F.retrieveMeta(uuid)
-      url <- Uri.fromString(s"/$uuid/${fileInfo.filename.getOrElse("download")}").leftMap(_.asInstanceOf[Throwable]).raiseOrPure[F]
+      url <- Uri.fromString(s"/$uuid/${fileInfo.filename.getOrElse("download")}").leftWiden[Throwable].raiseOrPure[F]
       resp <- TemporaryRedirect(Location(url))
     } yield resp
 

--- a/files/src/test/scala/h4sm/files/infrastructure/endpoint/FilesClient.scala
+++ b/files/src/test/scala/h4sm/files/infrastructure/endpoint/FilesClient.scala
@@ -42,7 +42,7 @@ class FilesClient[F[_] : ContextShift](fileEndpoints : FileEndpoints[F])(implici
   }
 
   def getFile(uuid : UUID, name : String = "download")(implicit h : Headers) : F[Stream[F, Byte]] = for {
-    u <- Uri.fromString(s"/${uuid.toString}/$name").leftMap(_.asInstanceOf[Throwable]).raiseOrPure[F]
+    u <- Uri.fromString(s"/${uuid.toString}/$name").leftWiden[Throwable].raiseOrPure[F]
     req <- GET(u)
     resp <- files.run(req.withHeaders(h))
     _ <- passOk(resp)

--- a/files/src/test/scala/h4sm/files/infrastructure/package.scala
+++ b/files/src/test/scala/h4sm/files/infrastructure/package.scala
@@ -1,7 +1,7 @@
 package h4sm.files
 
 import cats.effect.IO
-import cats.syntax.either._
+import cats.implicits._
 import com.typesafe.config.ConfigFactory
 import doobie.util.transactor.Transactor
 import h4sm.db.config.DatabaseConfig
@@ -22,7 +22,7 @@ package object infrastructure {
     ConfigFactory
       .load()
       .as[DatabaseConfig]("db")
-      .leftMap(_.asInstanceOf[Throwable])
+      .leftWiden[Throwable]
       .raiseOrPure[IO]
       .flatMap(getInitializedTransactor(_, schemaNames : _*))
       .unsafeRunSync()

--- a/permissions/src/test/scala/h4sm/permissions/infrastructure/endpoint/PermissionClient.scala
+++ b/permissions/src/test/scala/h4sm/permissions/infrastructure/endpoint/PermissionClient.scala
@@ -28,7 +28,7 @@ class PermissionClient[F[_] : Sync, Alg](es : PermissionEndpoints[F, Alg]) exten
   } yield ()
 
   def getPermissions(appName : String): F[List[(Permission, PermissionId)]] = for {
-    u <- Uri.fromString(s"/$appName").leftMap(_.asInstanceOf[Throwable]).raiseOrPure[F]
+    u <- Uri.fromString(s"/$appName").leftWiden[Throwable].raiseOrPure[F]
     req <- GET(u)
     res <- endpoints.run(req)
     perms <- res.as[SiteResult[List[(Permission, PermissionId)]]]

--- a/permissions/src/test/scala/h4sm/permissions/infrastructure/repository/persistent/sql/transactor.scala
+++ b/permissions/src/test/scala/h4sm/permissions/infrastructure/repository/persistent/sql/transactor.scala
@@ -16,7 +16,7 @@ object transactor {
     ConfigFactory
       .load()
       .as[DatabaseConfig]("db")
-      .leftMap(_.asInstanceOf[Throwable])
+      .leftWiden[Throwable]
       .raiseOrPure[F]
       .flatMap(getInitializedTransactor[F](_, "ct_auth", "ct_permissions"))
 

--- a/src/main/scala/h4sm/package.scala
+++ b/src/main/scala/h4sm/package.scala
@@ -13,7 +13,7 @@ package object h4sm {
 
   def getPureConfigAsk[F[_]: Sync, C: Decoder] : ApplicativeAsk[F, C] =
     new DefaultApplicativeAsk[F, C] {
-      val c : F[C] = ConfigFactory.load().as[C].leftMap(_.asInstanceOf[Throwable]).raiseOrPure[F]
+      val c : F[C] = ConfigFactory.load().as[C].leftWiden[Throwable].raiseOrPure[F]
       val applicative: Applicative[F] = implicitly
       def ask: F[C] = c
     }


### PR DESCRIPTION
`leftWiden` from Bifunctor allows us to widen the type of the error side of an Either safely, so that we can use raiseOrPure.