### PR TITLE
Use snapshot release for http4s instead of locally published

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ val commonSettings = Seq(
   scalaVersion := Version.scalaVersion,
   resolvers ++= addResolvers,
   scalacOptions ++= options.scalac,
-  scalacOptions in (Compile, console) ~= (_.filterNot(options.badScalacConsoleFlags.contains(_)))
+  scalacOptions in (Compile, console) ~= (_.filterNot(options.badScalacConsoleFlags.contains(_))),
+  updateOptions := updateOptions.value.withLatestSnapshots(false)
 ) ++ compilerPlugins
 
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,8 @@ import sbt.librarymanagement.DependencyBuilders
 object dependencies {
   val addResolvers = Seq(
     "52north for postgis" at "http://52north.org/maven/repo/releases/",
-    "jmcardon at bintray" at "https://dl.bintray.com/jmcardon/tsec",
-    Resolver.sonatypeRepo("releases")
+    Resolver.sonatypeRepo("releases"),
+    Resolver.sonatypeRepo("snapshots"),     
   )
   
   val compilerPlugins = Seq(
@@ -22,7 +22,7 @@ object dependencies {
   val cryptobits = "1.1"
   val doobie = "0.6.0"
   val flyway = "5.2.4"
-  val http4s = "0.20.0-M5-ct"
+  val http4s = "0.20.0-SNAPSHOT"
   val logback = "1.2.3"
   val postgres = "42.2.5"
   val scalaCheck = "1.14.0"

--- a/script/travis_init.sh
+++ b/script/travis_init.sh
@@ -11,15 +11,8 @@ psql -c 'create database ct_files_test;' -U postgres
 psql -c 'create database ct_feature_requests_test;' -U postgres  
 psql -c 'create database h4sm_docs_gen' -U postgres
 
-
 # Modules we have to publish locally because we're 
 # waiting on releases from them.
-git clone https://github.com/zakpatterson/http4s
-cd http4s
-git checkout v0.20.0-M5-ct
-sbt publishLocal
-cd ..
-
 git clone https://github.com/zakpatterson/tsec
 cd tsec/
 git checkout 0.1.1-ct


### PR DESCRIPTION
We can use a snapshot release of http4s for now, still have to publish tsec locally.