### PR TITLE
Add defaultSchema setting, which Flyway warns now must be explicit

### DIFF
--- a/modules/db/jvm/src/main/scala/h4sm/db/config/DatabaseConfig.scala
+++ b/modules/db/jvm/src/main/scala/h4sm/db/config/DatabaseConfig.scala
@@ -27,6 +27,7 @@ object DatabaseConfig {
       Flyway
         .configure()
         .dataSource(ds)
+        .defaultSchema(schemaName)
         .schemas(schemaName)
         .locations(s"db/$schemaName/migration")
         .load()


### PR DESCRIPTION
Getting rid of these warnings:
```
[pool-12-thread-5-ScalaTest-running-InvitationEndpointTestSpec] WARN  o.f.core.Flyway - Using the first specified schema ct_auth as default schema. From Flyway 6.1 you can specify defaultSchema explicitly in your configuration, and from Flyway 7 this will become mandatory. 

[pool-12-thread-5-ScalaTest-running-InvitationEndpointTestSpec] WARN  o.f.core.Flyway - Using the first specified schema ct_invitations as default schema. From Flyway 6.1 you can specify defaultSchema explicitly in your configuration, and from Flyway 7 this will become mandatory. 

[pool-12-thread-8-ScalaTest-running-PermissionEndpointsTestSpec] WARN  o.f.core.Flyway - Using the first specified schema ct_auth as default schema. From Flyway 6.1 you can specify defaultSchema explicitly in your configuration, and from Flyway 7 this will become mandatory. 

[pool-12-thread-8-ScalaTest-running-PermissionEndpointsTestSpec] WARN  o.f.core.Flyway - Using the first specified schema ct_permissions as default schema. From Flyway 6.1 you can specify defaultSchema explicitly in your configuration, and from Flyway 7 this will become mandatory. 
```